### PR TITLE
Updated to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>bootstrap-datepicker</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>Bootstrap Datepicker</name>
     <description>WebJar for Bootstrap Datepicker</description>
     <url>http://webjars.org</url>
@@ -25,9 +25,9 @@
     </licenses>
 
     <scm>
-        <url>http://github.com/webjars/bootstrap-datepicker</url>
-        <connection>scm:git:https://github.com/webjars/bootstrap-datepicker.git</connection>
-        <developerConnection>scm:git:https://github.com/webjars/bootstrap-datepicker.git</developerConnection>
+        <url>http://github.com/webjars/${project.artifactId}</url>
+        <connection>scm:git:https://github.com/webjars/${project.artifactId}.git</connection>
+        <developerConnection>scm:git:https://github.com/webjars/${project.artifactId}.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 
@@ -41,7 +41,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>1.1.3</upstreamVersion>
+        <upstreamVersion>1.2.0</upstreamVersion>
         <sourceUrl>https://github.com/eternicode/bootstrap-datepicker/archive</sourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
     </properties>


### PR DESCRIPTION
I also changed the scm block to use ${project.artifactId}. My thinking is to make WebJar POMs as generic as possible so they're easier to create, perhaps from a standard template or archetype.
